### PR TITLE
fix for configuration where target file doesn't exist

### DIFF
--- a/Configuration/Configure.ps1
+++ b/Configuration/Configure.ps1
@@ -3,8 +3,9 @@
   if (Test-Path "$targetFileName")
   {
     Remove-Item "$targetFileName"
-    $srcFileName = $tempalteFileName
   }
+  $srcFileName = $tempalteFileName
+  
   
   (Get-Content -Encoding UTF8 $srcFileName) | ForEach-Object { $_ -replace $variableName, $value } | Set-Content -Encoding UTF8 $targetFileName
 }


### PR DESCRIPTION
Hello,
I just found your project and I couldn't wait to use it and collaborate!

At first start the configure.bat didn't work because no `$targetFileName` was present, so `$srcFileName` didn't initialize properly.

With this small fix I was able to solve the problem.