### PR TITLE
feat: add clean attributes extension method

### DIFF
--- a/Sources/Linq2Acad/Extensions/AttributeCollectionExtensions.cs
+++ b/Sources/Linq2Acad/Extensions/AttributeCollectionExtensions.cs
@@ -27,6 +27,12 @@ namespace Linq2Acad
       attribute.TextString = value;
     }
 
+    public static void CleanValues(this AttributeCollection attributes)
+    {
+      GetAttributeReferences(attributes, OpenMode.ForWrite)
+        .ForEach(ar => ar.TextString = "");
+    }
+
     private static AttributeReference GetAttributeReference(AttributeCollection attributes, string tag, OpenMode openMode)
     {
       var attribute = GetAttributeReferences(attributes, openMode)


### PR DESCRIPTION
Since you asked for it... 😉 

This will add a `CleanValues` extension method to `AttributeCollection` that empties all the `TextString`s.

I had to add it directly to Linq2Acad because the method uses the private method `GetAttributeReferences`.
