### PR TITLE
add: group extensions

### DIFF
--- a/src/AutoCAD_2015/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2015/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2016/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2016/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2017/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2017/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2018/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2018/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2019/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2019/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2020/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2020/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2021/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2021/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2022/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2022/Linq2Acad/Linq2Acad.csproj
@@ -187,6 +187,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Containers\XRef\XRefContainer.cs">
       <Link>Containers\XRef\XRefContainer.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/AutoCAD_2023/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2023/Linq2Acad/Linq2Acad.csproj
@@ -181,6 +181,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Extensions\LayerTableRecordExtensions.cs">
       <Link>Extensions\LayerTableRecordExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+      <Link>Extensions\GroupExtensions.cs</Link>
+    </Compile>
     <Compile Include="..\..\Sources\Linq2Acad\AcadSummaryInfo.cs">
       <Link>AcadSummaryInfo.cs</Link>
     </Compile>

--- a/src/Sources/Linq2Acad.SampleCode.CS/SampleCode.cs
+++ b/src/Sources/Linq2Acad.SampleCode.CS/SampleCode.cs
@@ -11,363 +11,428 @@ using Autodesk.AutoCAD.Runtime;
 
 namespace Linq2Acad
 {
-  public partial class SampleCode
-  {
-    /// <summary>
-    /// This sample removes all entities from the model space
-    /// </summary>
-    [CommandMethod("Linq2AcadExample1")]
-    public void RemovingAllEntitiesFromTheModelSpace()
+    public partial class SampleCode
     {
-      WriteMessage("This sample removes all entities from the model space");
-
-      using (var db = AcadDatabase.Active())
-      {
-        db.ModelSpace
-          .Clear();
-      }
-
-      WriteMessage("Model space cleared");
-    }
-
-    /// <summary>
-    /// This sample removes all BlockReferences from the model space
-    /// </summary>
-    [CommandMethod("Linq2AcadExample2")]
-    public void ErasingAllBlockReferencesFromTheModelSpace()
-    {
-      WriteMessage("This sample removes all BlockReferences from the model space");
-
-      using (var db = AcadDatabase.Active())
-      {
-        foreach (var br in db.ModelSpace
-                             .OfType<BlockReference>()
-                             .UpgradeOpen())
+        /// <summary>
+        /// This sample removes all entities from the model space
+        /// </summary>
+        [CommandMethod("Linq2AcadExample1")]
+        public void RemovingAllEntitiesFromTheModelSpace()
         {
-          br.Erase();
-        }
-      }
+            WriteMessage("This sample removes all entities from the model space");
 
-      WriteMessage("All block references removed from model space");
-    }
+            using (var db = AcadDatabase.Active())
+            {
+                db.ModelSpace
+                  .Clear();
+            }
 
-    /// <summary>
-    /// This sample adds a line to the model space
-    /// </summary>
-    [CommandMethod("Linq2AcadExample3")]
-    public void AddingALineToTheModelSpace()
-    {
-      WriteMessage("This sample adds a line to the model space");
-
-      using (var db = AcadDatabase.Active())
-      {
-        db.ModelSpace
-          .Add(new Line(Point3d.Origin,
-                        new Point3d(100, 100, 0)));
-      }
-
-      WriteMessage("Line added to model space");
-    }
-
-    /// <summary>
-    /// This sample creates a new layer
-    /// </summary>
-    [CommandMethod("Linq2AcadExample4")]
-    public void CreatingANewLayer()
-    {
-      WriteMessage("This sample creates a new layer");
-
-      var layerName = GetString("Enter layer name");
-      var colorName = GetString("Enter color name");
-
-      if (layerName != null &&
-          colorName != null)
-      {
-        using (var db = AcadDatabase.Active())
-        {
-          var layer = db.Layers.Create(layerName);
-          layer.Color = Color.FromColor(System.Drawing.Color.FromName(colorName));
+            WriteMessage("Model space cleared");
         }
 
-        WriteMessage($"Layer {layerName} created");
-      }
-    }
-
-    /// <summary>
-    /// This sample prints all layer names
-    /// </summary>
-    [CommandMethod("Linq2AcadExample5")]
-    public void PrintingAllLayerNames()
-    {
-      WriteMessage("This sample prints all layer names");
-
-      using (var db = AcadDatabase.Active())
-      {
-        foreach (var layer in db.Layers)
+        /// <summary>
+        /// This sample removes all BlockReferences from the model space
+        /// </summary>
+        [CommandMethod("Linq2AcadExample2")]
+        public void ErasingAllBlockReferencesFromTheModelSpace()
         {
-          WriteMessage(layer.Name);
-        }
-      }
-    }
+            WriteMessage("This sample removes all BlockReferences from the model space");
 
-    /// <summary>
-    /// This sample turns off all layers, except the one the user enters
-    /// </summary>
-    [CommandMethod("Linq2AcadExample6")]
-    public void TurningOffAllLayersExceptTheOneTheUserEnters()
-    {
-      WriteMessage("This sample turns off all layers, except the one the user enters");
+            using (var db = AcadDatabase.Active())
+            {
+                foreach (var br in db.ModelSpace
+                                     .OfType<BlockReference>()
+                                     .UpgradeOpen())
+                {
+                    br.Erase();
+                }
+            }
 
-      var layerName = GetString("Enter layer name");
-
-      if (layerName != null)
-      {
-        using (var db = AcadDatabase.Active())
-        {
-          var layerToIgnore = db.Layers
-                                .Element(layerName);
-
-          foreach (var layer in db.Layers
-                                  .Except(layerToIgnore)
-                                  .UpgradeOpen())
-          {
-            layer.IsOff = true;
-          }
+            WriteMessage("All block references removed from model space");
         }
 
-        WriteMessage($"All layers turned off, except {layerName}");
-      }
-    }
-
-    /// <summary>
-    /// This sample creates a layer and adds all red lines in the model space to it
-    /// </summary>
-    [CommandMethod("Linq2AcadExample7")]
-    public void CreatingALayerAndAddingAllRedLinesInTheModelSpaceToIt()
-    {
-      WriteMessage("This sample creates a layer and This sample adds all red lines in the model space to it");
-
-      var layerName = GetString("Enter layer name");
-
-      if (layerName != null)
-      {
-        using (var db = AcadDatabase.Active())
+        /// <summary>
+        /// This sample adds a line to the model space
+        /// </summary>
+        [CommandMethod("Linq2AcadExample3")]
+        public void AddingALineToTheModelSpace()
         {
-          var lines = db.ModelSpace
-                        .OfType<Line>()
-                        .Where(l => l.Color.ColorValue.Name == "ffff0000");
-          db.Layers
-            .Create(layerName, lines);
+            WriteMessage("This sample adds a line to the model space");
+
+            using (var db = AcadDatabase.Active())
+            {
+                db.ModelSpace
+                  .Add(new Line(Point3d.Origin,
+                                new Point3d(100, 100, 0)));
+            }
+
+            WriteMessage("Line added to model space");
         }
 
-        WriteMessage($"All red lines moved to new layer {layerName}");
-      }
-    }
-
-    /// <summary>
-    /// This sample moves entities from one layer to another
-    /// </summary>
-    [CommandMethod("Linq2AcadExample8")]
-    public void MovingEntitiesFromOneLayerToAnother()
-    {
-      WriteMessage("This sample moves entities from one layer to another");
-
-      var sourceLayerName = GetString("Enter source layer name");
-      var targetLayerName = GetString("Enter target layer name");
-
-      if (sourceLayerName != null && targetLayerName != null)
-      {
-        using (var db = AcadDatabase.Active())
+        /// <summary>
+        /// This sample creates a new layer
+        /// </summary>
+        [CommandMethod("Linq2AcadExample4")]
+        public void CreatingANewLayer()
         {
-          var entities = db.CurrentSpace
-                           .Where(e => e.Layer == sourceLayerName);
-          db.Layers
-            .Element(targetLayerName)
-            .AddRange(entities);
+            WriteMessage("This sample creates a new layer");
+
+            var layerName = GetString("Enter layer name");
+            var colorName = GetString("Enter color name");
+
+            if (layerName != null &&
+                colorName != null)
+            {
+                using (var db = AcadDatabase.Active())
+                {
+                    var layer = db.Layers.Create(layerName);
+                    layer.Color = Color.FromColor(System.Drawing.Color.FromName(colorName));
+                }
+
+                WriteMessage($"Layer {layerName} created");
+            }
         }
 
-        WriteMessage($"All entities on layer {sourceLayerName} moved to layer {targetLayerName}");
-      }
-    }
-
-    /// <summary>
-    /// This sample imports a block from a drawing file
-    /// </summary>
-    [CommandMethod("Linq2AcadExample9")]
-    public void ImportingABlockFromADrawingFile()
-    {
-      WriteMessage("This sample imports a block from a drawing file");
-
-      var filePath = GetString("Enter file path");
-      var blockName = GetString("Enter block name");
-
-      if (filePath != null && blockName != null)
-      {
-        using (var sourceDb = AcadDatabase.OpenReadOnly(filePath))
+        /// <summary>
+        /// This sample prints all layer names
+        /// </summary>
+        [CommandMethod("Linq2AcadExample5")]
+        public void PrintingAllLayerNames()
         {
-          var block = sourceDb.Blocks
-                              .Element(blockName);
+            WriteMessage("This sample prints all layer names");
 
-          using (var activeDb = AcadDatabase.Active())
-          {
-            activeDb.Blocks
-                    .Import(block);
-          }
+            using (var db = AcadDatabase.Active())
+            {
+                foreach (var layer in db.Layers)
+                {
+                    WriteMessage(layer.Name);
+                }
+            }
         }
 
-        WriteMessage($"Block {blockName} imported");
-      }
-    }
-
-    /// <summary>
-    /// This sample opens a drawing from file and counts the BlockReferences in the model space
-    /// </summary>
-    [CommandMethod("Linq2AcadExample10")]
-    public void OpeningADrawingFromFileAndCountingTheBlockReferencesInTheModelSpace()
-    {
-      WriteMessage("This sample opens a drawing from file and counting the BlockReferences in the model space");
-
-      var filePath = GetString("Enter file path");
-
-      if (filePath != null)
-      {
-        using (var db = AcadDatabase.OpenReadOnly(filePath))
+        /// <summary>
+        /// This sample turns off all layers, except the one the user enters
+        /// </summary>
+        [CommandMethod("Linq2AcadExample6")]
+        public void TurningOffAllLayersExceptTheOneTheUserEnters()
         {
-          var count = db.ModelSpace
-                        .OfType<BlockReference>()
-                        .Count();
+            WriteMessage("This sample turns off all layers, except the one the user enters");
 
-          WriteMessage($"Model space block references in file {filePath}: {count}");
-        }
-      }
-    }
+            var layerName = GetString("Enter layer name");
 
-    /// <summary>
-    /// This sample picks an entity and saves a string on it
-    /// </summary>
-    [CommandMethod("Linq2AcadExample11")]
-    public void PickingAnEntityAndSavingAStringOnIt()
-    {
-      WriteMessage("This sample picks an entity and saves a string on it");
+            if (layerName != null)
+            {
+                using (var db = AcadDatabase.Active())
+                {
+                    var layerToIgnore = db.Layers
+                                          .Element(layerName);
 
-      var entityId = GetEntity("Pick an entity");
-      var key = GetString("Enter key");
-      var str = GetString("Enter string to save");
+                    foreach (var layer in db.Layers
+                                            .Except(layerToIgnore)
+                                            .UpgradeOpen())
+                    {
+                        layer.IsOff = true;
+                    }
+                }
 
-      if (entityId.IsValid && key != null && str != null)
-      {
-        using (var db = AcadDatabase.Active())
-        {
-          db.CurrentSpace
-            .Element(entityId)
-            .SaveData(key, str);
+                WriteMessage($"All layers turned off, except {layerName}");
+            }
         }
 
-        WriteMessage($"Key-value-pair {key}:{str} saved on entity");
-      }
-    }
-
-    /// <summary>
-    /// This sample picks an entity and reads a string from it
-    /// </summary>
-    [CommandMethod("Linq2AcadExample12")]
-    public void PickingAnEntityAndReadingAStringFromIt()
-    {
-      WriteMessage("This sample picks an entity and reads a string from it");
-
-      var entityId = GetEntity("Pick an entity");
-      var key = GetString("Enter key");
-
-      if (entityId.IsValid && key != null)
-      {
-        using (var db = AcadDatabase.Active())
+        /// <summary>
+        /// This sample creates a layer and adds all red lines in the model space to it
+        /// </summary>
+        [CommandMethod("Linq2AcadExample7")]
+        public void CreatingALayerAndAddingAllRedLinesInTheModelSpaceToIt()
         {
-          var str = db.CurrentSpace
+            WriteMessage("This sample creates a layer and This sample adds all red lines in the model space to it");
+
+            var layerName = GetString("Enter layer name");
+
+            if (layerName != null)
+            {
+                using (var db = AcadDatabase.Active())
+                {
+                    var lines = db.ModelSpace
+                                  .OfType<Line>()
+                                  .Where(l => l.Color.ColorValue.Name == "ffff0000");
+                    db.Layers
+                      .Create(layerName, lines);
+                }
+
+                WriteMessage($"All red lines moved to new layer {layerName}");
+            }
+        }
+
+        /// <summary>
+        /// This sample moves entities from one layer to another
+        /// </summary>
+        [CommandMethod("Linq2AcadExample8")]
+        public void MovingEntitiesFromOneLayerToAnother()
+        {
+            WriteMessage("This sample moves entities from one layer to another");
+
+            var sourceLayerName = GetString("Enter source layer name");
+            var targetLayerName = GetString("Enter target layer name");
+
+            if (sourceLayerName != null && targetLayerName != null)
+            {
+                using (var db = AcadDatabase.Active())
+                {
+                    var entities = db.CurrentSpace
+                                     .Where(e => e.Layer == sourceLayerName);
+                    db.Layers
+                      .Element(targetLayerName)
+                      .AddRange(entities);
+                }
+
+                WriteMessage($"All entities on layer {sourceLayerName} moved to layer {targetLayerName}");
+            }
+        }
+
+        /// <summary>
+        /// This sample imports a block from a drawing file
+        /// </summary>
+        [CommandMethod("Linq2AcadExample9")]
+        public void ImportingABlockFromADrawingFile()
+        {
+            WriteMessage("This sample imports a block from a drawing file");
+
+            var filePath = GetString("Enter file path");
+            var blockName = GetString("Enter block name");
+
+            if (filePath != null && blockName != null)
+            {
+                using (var sourceDb = AcadDatabase.OpenReadOnly(filePath))
+                {
+                    var block = sourceDb.Blocks
+                                        .Element(blockName);
+
+                    using (var activeDb = AcadDatabase.Active())
+                    {
+                        activeDb.Blocks
+                                .Import(block);
+                    }
+                }
+
+                WriteMessage($"Block {blockName} imported");
+            }
+        }
+
+        /// <summary>
+        /// This sample opens a drawing from file and counts the BlockReferences in the model space
+        /// </summary>
+        [CommandMethod("Linq2AcadExample10")]
+        public void OpeningADrawingFromFileAndCountingTheBlockReferencesInTheModelSpace()
+        {
+            WriteMessage("This sample opens a drawing from file and counting the BlockReferences in the model space");
+
+            var filePath = GetString("Enter file path");
+
+            if (filePath != null)
+            {
+                using (var db = AcadDatabase.OpenReadOnly(filePath))
+                {
+                    var count = db.ModelSpace
+                                  .OfType<BlockReference>()
+                                  .Count();
+
+                    WriteMessage($"Model space block references in file {filePath}: {count}");
+                }
+            }
+        }
+
+        /// <summary>
+        /// This sample picks an entity and saves a string on it
+        /// </summary>
+        [CommandMethod("Linq2AcadExample11")]
+        public void PickingAnEntityAndSavingAStringOnIt()
+        {
+            WriteMessage("This sample picks an entity and saves a string on it");
+
+            var entityId = GetEntity("Pick an entity");
+            var key = GetString("Enter key");
+            var str = GetString("Enter string to save");
+
+            if (entityId.IsValid && key != null && str != null)
+            {
+                using (var db = AcadDatabase.Active())
+                {
+                    db.CurrentSpace
                       .Element(entityId)
-                      .GetData<string>(key);
+                      .SaveData(key, str);
+                }
 
-          WriteMessage($"String {str} read from entity");
+                WriteMessage($"Key-value-pair {key}:{str} saved on entity");
+            }
         }
-      }
-    }
 
-    /// <summary>
-    /// This sample picks an entity and reads a string from it (with XData as the data source)
-    /// </summary>
-    [CommandMethod("Linq2AcadExample13")]
-    public void PickingAnEntityAndReadingAStringFromItWithXDataAsTheDataSource()
-    {
-      WriteMessage("This sample picks an entity and reads a string from it (with XData as the data source)");
-
-      var entityId = GetEntity("Pick an entity");
-      var key = GetString("Enter RegApp name");
-
-      if (entityId.IsValid && key != null)
-      {
-        using (var db = AcadDatabase.Active())
+        /// <summary>
+        /// This sample picks an entity and reads a string from it
+        /// </summary>
+        [CommandMethod("Linq2AcadExample12")]
+        public void PickingAnEntityAndReadingAStringFromIt()
         {
-          var str = db.CurrentSpace
-                      .Element(entityId)
-                      .GetData<string>(key, true);
+            WriteMessage("This sample picks an entity and reads a string from it");
 
-          WriteMessage($"String {str} read from entity's XData");
+            var entityId = GetEntity("Pick an entity");
+            var key = GetString("Enter key");
+
+            if (entityId.IsValid && key != null)
+            {
+                using (var db = AcadDatabase.Active())
+                {
+                    var str = db.CurrentSpace
+                                .Element(entityId)
+                                .GetData<string>(key);
+
+                    WriteMessage($"String {str} read from entity");
+                }
+            }
         }
-      }
-    }
 
-    /// <summary>
-    /// This sample counts the number of entities in all paper space layouts
-    /// </summary>
-    [CommandMethod("Linq2AcadExample14")]
-    public void CountingTheNumberOfEntitiesInAllPaperSpaceLayouts()
-    {
-      WriteMessage("This sample counts the number of entities in all paper space layouts");
-
-      using (var db = AcadDatabase.Active())
-      {
-        var count = db.PaperSpace
-                      .SelectMany(ps => ps)
-                      .Count();
-
-        WriteMessage($"{count} entities in all paper space layouts");
-      }
-    }
-
-    /// <summary>
-    /// This sample changes the summary info
-    /// </summary>
-    [CommandMethod("Linq2AcadExample15")]
-    public void ChangingTheSummaryInfo()
-    {
-      WriteMessage("This sample changes the summary info");
-
-      using (var db = AcadDatabase.Active())
-      {
-        db.SummaryInfo.Author = "John Doe";
-        db.SummaryInfo.CustomProperties["CustomData1"] = "42";
-      }
-
-      WriteMessage("Summary info updated");
-    }
-
-    /// <summary>
-    /// This sample reloads all loaded XRefs
-    /// </summary>
-    [CommandMethod("Linq2AcadExample16")]
-    public void ReloadingAllLoadedXRefs()
-    {
-      WriteMessage("This sample reloads all loaded XRefs");
-
-      using (var db = AcadDatabase.Active())
-      {
-        foreach (var xRef in db.XRefs
-                               .Where(xr => xr.IsLoaded))
+        /// <summary>
+        /// This sample picks an entity and reads a string from it (with XData as the data source)
+        /// </summary>
+        [CommandMethod("Linq2AcadExample13")]
+        public void PickingAnEntityAndReadingAStringFromItWithXDataAsTheDataSource()
         {
-          xRef.Reload();
-        }
-      }
+            WriteMessage("This sample picks an entity and reads a string from it (with XData as the data source)");
 
-      WriteMessage("XRefs reloaded");
+            var entityId = GetEntity("Pick an entity");
+            var key = GetString("Enter RegApp name");
+
+            if (entityId.IsValid && key != null)
+            {
+                using (var db = AcadDatabase.Active())
+                {
+                    var str = db.CurrentSpace
+                                .Element(entityId)
+                                .GetData<string>(key, true);
+
+                    WriteMessage($"String {str} read from entity's XData");
+                }
+            }
+        }
+
+        /// <summary>
+        /// This sample counts the number of entities in all paper space layouts
+        /// </summary>
+        [CommandMethod("Linq2AcadExample14")]
+        public void CountingTheNumberOfEntitiesInAllPaperSpaceLayouts()
+        {
+            WriteMessage("This sample counts the number of entities in all paper space layouts");
+
+            using (var db = AcadDatabase.Active())
+            {
+                var count = db.PaperSpace
+                              .SelectMany(ps => ps)
+                              .Count();
+
+                WriteMessage($"{count} entities in all paper space layouts");
+            }
+        }
+
+        /// <summary>
+        /// This sample changes the summary info
+        /// </summary>
+        [CommandMethod("Linq2AcadExample15")]
+        public void ChangingTheSummaryInfo()
+        {
+            WriteMessage("This sample changes the summary info");
+
+            using (var db = AcadDatabase.Active())
+            {
+                db.SummaryInfo.Author = "John Doe";
+                db.SummaryInfo.CustomProperties["CustomData1"] = "42";
+            }
+
+            WriteMessage("Summary info updated");
+        }
+
+        /// <summary>
+        /// This sample reloads all loaded XRefs
+        /// </summary>
+        [CommandMethod("Linq2AcadExample16")]
+        public void ReloadingAllLoadedXRefs()
+        {
+            WriteMessage("This sample reloads all loaded XRefs");
+
+            using (var db = AcadDatabase.Active())
+            {
+                foreach (var xRef in db.XRefs
+                                       .Where(xr => xr.IsLoaded))
+                {
+                    xRef.Reload();
+                }
+            }
+
+            WriteMessage("XRefs reloaded");
+        }
+
+        [CommandMethod("AddEntitiesToGroup")]
+        public void AddEntitiesToGroup()
+        {
+            using (var db = AcadDatabase.Active())
+            {
+                Group group1 = db.Groups.CreateOrFind("Group1");
+                group1.Append(create10Lines(db)); // append lines
+
+
+                List<Line> lines = create10Lines(db);
+                group1.InsertAt(1, lines);         // insert at lines       
+                group1.RemoveAt(1, lines);         // remove at lines
+
+
+                List<Line> lines2 = create10Lines(db);
+                Group group2 = db.Groups.CreateOrFind("Group2");
+                group2.Append(lines2.Select(line => line.ObjectId));   // append using objectIds
+                group2.Remove(lines2.Select(line => line.ObjectId));   // remove at using objectIds
+
+
+                Group group3 = db.Groups.CreateOrFind("Group3");
+                List<Entity> entities = create10Lines(db).Cast<Entity>().ToList();
+                group3.InsertAt(0, entities); // insert at entities
+                group3.RemoveAt(0, entities); // remove at entities               
+
+
+                Group group4 = db.Groups.CreateOrFind("Group4");
+                group4.InsertAt(0, create10Lines(db).Select(line => line.ObjectId)); // insert at object ids
+                group4.RemoveAt(0, group4.GetAllEntityIds()); // remove at object ids
+            }
+
+            List<Line> create10Lines(AcadDatabase db)
+            {
+                Random randomizer = new Random();
+                List<Line> lines = new List<Line>();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    int aX = randomizer.Next(-1000, 1000);
+                    int aY = randomizer.Next(-1000, 1000);
+
+                    int bX = randomizer.Next(-1000, 1000);
+                    int bY = randomizer.Next(-1000, 1000);
+
+                    Line line = new Line(new Point3d(aX, aY, 0), new Point3d(bX, bY, 0));
+                    lines.Add(line);
+                }
+
+                db.ModelSpace.AddRange(lines);
+
+                return lines;
+            }
+        }
     }
-  }
+
+
+    public static class GroupExtensions
+    {
+        public static Group CreateOrFind(this GroupContainer container, string groupName)
+          => container.Contains(groupName)
+               ? container.Element(groupName)
+               : container.Create(groupName);
+    }
+
+
 }

--- a/src/Sources/Linq2Acad.SampleCode.CS/SampleCode.cs
+++ b/src/Sources/Linq2Acad.SampleCode.CS/SampleCode.cs
@@ -376,32 +376,34 @@ namespace Linq2Acad
             using (var db = AcadDatabase.Active())
             {
                 Group group1 = db.Groups.CreateOrFind("Group1");
-                group1.Append(create10Lines(db)); // append lines
+                group1.Append(createEntities(db)); // append lines
 
 
-                List<Line> lines = create10Lines(db);
+                List<Line> lines = createEntities(db);
                 group1.InsertAt(1, lines);         // insert at lines       
                 group1.RemoveAt(1, lines);         // remove at lines
 
 
-                List<Line> lines2 = create10Lines(db);
+                List<Line> lines2 = createEntities(db);
                 Group group2 = db.Groups.CreateOrFind("Group2");
                 group2.Append(lines2.Select(line => line.ObjectId));   // append using objectIds
                 group2.Remove(lines2.Select(line => line.ObjectId));   // remove at using objectIds
 
 
                 Group group3 = db.Groups.CreateOrFind("Group3");
-                List<Entity> entities = create10Lines(db).Cast<Entity>().ToList();
+                List<Entity> entities = createEntities(db).Cast<Entity>().ToList();
                 group3.InsertAt(0, entities); // insert at entities
                 group3.RemoveAt(0, entities); // remove at entities               
 
 
                 Group group4 = db.Groups.CreateOrFind("Group4");
-                group4.InsertAt(0, create10Lines(db).Select(line => line.ObjectId)); // insert at object ids
+                group4.InsertAt(0, createEntities(db).Select(line => line.ObjectId)); // insert at object ids
                 group4.RemoveAt(0, group4.GetAllEntityIds()); // remove at object ids
+
+                Group group5 = db.Groups.CreateOrFind("Group5", createEntities(db));
             }
 
-            List<Line> create10Lines(AcadDatabase db)
+            List<Line> createEntities(AcadDatabase db)
             {
                 Random randomizer = new Random();
                 List<Line> lines = new List<Line>();
@@ -432,6 +434,11 @@ namespace Linq2Acad
           => container.Contains(groupName)
                ? container.Element(groupName)
                : container.Create(groupName);
+
+        public static Group CreateOrFind(this GroupContainer container, string groupName, IEnumerable<Entity> entities)
+            => container.Contains(groupName)
+               ? container.Element(groupName)
+               : container.Create(groupName, entities);
     }
 
 

--- a/src/Sources/Linq2Acad/Containers/DBDictionary/GroupContainer.cs
+++ b/src/Sources/Linq2Acad/Containers/DBDictionary/GroupContainer.cs
@@ -31,15 +31,7 @@ namespace Linq2Acad
       Require.NameDoesNotExist<Group>(Contains(name), name);
 
       var group = AddInternal(new Group(), name);
-
-      if (entities.Any())
-      {
-        using (var idCollection = new ObjectIdCollection(entities.Select(e => e.ObjectId)
-                                                                  .ToArray()))
-        {
-          group.Append(idCollection);
-        }
-      }
+      group.Append(entities);      
 
       return group;
     }

--- a/src/Sources/Linq2Acad/Containers/DBDictionary/GroupContainer.cs
+++ b/src/Sources/Linq2Acad/Containers/DBDictionary/GroupContainer.cs
@@ -8,32 +8,56 @@ using System.Collections;
 
 namespace Linq2Acad
 {
-  /// <summary>
-  /// A container class that provides access to the elements of the Group dictionary In addition to the standard LINQ operations this class provides methods to create, add and import Groups.
-  /// </summary>
-  public sealed class GroupContainer : DBDictionaryEnumerable<Group>
-  {
-    internal GroupContainer(Database database, Transaction transaction, ObjectId containerID)
-      : base(database, transaction, containerID, g => g.Name, () => nameof(Group.Name))
-    {
-    }
-
     /// <summary>
-    /// Creates a new Group with the specified name and adds the Entities to it.
+    /// A container class that provides access to the elements of the Group dictionary In addition to the standard LINQ operations this class provides methods to create, add and import Groups.
     /// </summary>
-    /// <param name="name">The unique name of the element.</param>
-    /// <param name="entities">The entities to be added to the Group.</param>
-    public Group Create(string name, IEnumerable<Entity> entities)
+    public sealed class GroupContainer : DBDictionaryEnumerable<Group>
     {
-      Require.NotDisposed(database.IsDisposed, nameof(AcadDatabase));
-      Require.TransactionNotDisposed(transaction.IsDisposed);
-      Require.IsValidSymbolName(name, nameof(name));
-      Require.NameDoesNotExist<Group>(Contains(name), name);
+        internal GroupContainer(Database database, Transaction transaction, ObjectId containerID)
+          : base(database, transaction, containerID, g => g.Name, () => nameof(Group.Name))
+        {
+        }
 
-      var group = AddInternal(new Group(), name);
-      group.Append(entities);      
+        /// <summary>
+        /// Creates a new Group with the specified name and adds the Entities to it.
+        /// </summary>
+        /// <param name="name">The unique name of the element.</param>
+        /// <param name="entities">The entities to be added to the Group.</param>
+        public Group Create(string name, IEnumerable<Entity> entities)
+        {
+            Require.NotDisposed(database.IsDisposed, nameof(AcadDatabase));
+            Require.TransactionNotDisposed(transaction.IsDisposed);
+            Require.IsValidSymbolName(name, nameof(name));
+            Require.NameDoesNotExist<Group>(Contains(name), name);
 
-      return group;
+            var group = AddInternal(new Group(), name);
+            group.Append(entities);
+
+            return group;
+        }
+        /// <summary>
+        /// Creates a new Group with the specified name and adds the object ids to it.
+        /// <example>        
+        /// <code>
+        /// Group group5 = db.Groups.Create("Group5", ids);        
+        /// </code>
+        /// results in a group5 with ids.
+        /// </example>
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="ids"></param>
+        /// <returns> Group </returns>
+        public Group Create(string name, IEnumerable<ObjectId> ids)
+        {
+            Require.NotDisposed(database.IsDisposed, nameof(AcadDatabase));
+            Require.TransactionNotDisposed(transaction.IsDisposed);
+            Require.IsValidSymbolName(name, nameof(name));
+            Require.NameDoesNotExist<Group>(Contains(name), name);
+
+            var group = AddInternal(new Group(), name);
+            group.Append(ids);
+
+            return group;
+        }
     }
-  }
 }

--- a/src/Sources/Linq2Acad/Extensions/GroupExtensions.cs
+++ b/src/Sources/Linq2Acad/Extensions/GroupExtensions.cs
@@ -1,0 +1,158 @@
+﻿using Autodesk.AutoCAD.DatabaseServices;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Linq2Acad
+{
+    /// <summary>
+    /// Extension records for instance of Group.
+    /// </summary>
+    public static class GroupExtensions
+    {   /// <summary>
+        /// Appends ids to group. (Note, this crystalises the ids to an array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="ids"></param>
+        public static void Append(this Group group, IEnumerable<ObjectId> ids)
+        {
+            ObjectId[] idsArray = ids.ToArray();
+
+            if (idsArray.Length > 0)
+            {
+                using (ObjectIdCollection idCollection = new ObjectIdCollection(idsArray))
+                {                    
+                    group.Append(idCollection); 
+                }
+            }
+        }
+
+        /// <summary>
+        /// Appends entities to group. (Note, this crystalises the entities to an object id array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="entities"></param>
+        public static void Append(this Group group, IEnumerable<Entity> entities)
+        {
+            group.Append(entities.Select(e => e.ObjectId));
+        }
+
+        /// <summary>
+        /// Prepends ids to group. (Note, this crystalises the ids to an array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="ids"></param>
+        public static void Prepend(this Group group, IEnumerable<ObjectId> ids)
+        {
+            ObjectId[] idsArray = ids.ToArray();
+
+            if (idsArray.Length > 0)
+            {
+                using (ObjectIdCollection idCollection = new ObjectIdCollection(idsArray))
+                {                    
+                    group.Prepend(idCollection); 
+                }
+            }
+        }
+
+        /// <summary>
+        /// Prepends entities to group. (Note, this crystalises the entities to an object id array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="entities"></param>
+        public static void Prepend(this Group group, IEnumerable<Entity> entities)
+        {
+            group.Prepend(entities.Select(e => e.ObjectId));
+        }
+
+        /// <summary>
+        /// Appends ids to group at the index required. (Note, this crystalises the ids to an array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="index"></param>
+        /// <param name="ids"></param>
+        public static void InsertAt(this Group group, int index, IEnumerable<ObjectId> ids)
+        {
+            ObjectId[] idsArray = ids.ToArray();
+
+            if (idsArray.Length > 0)
+            {
+                using (ObjectIdCollection idCollection = new ObjectIdCollection(idsArray))
+                {                    
+                    group.InsertAt(index, idCollection); 
+                }
+            }
+        }
+
+        /// <summary>
+        /// Appends entities to group at the index required. (Note, this crystalises the entities to an ids array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="index"></param>
+        /// <param name="entities"></param>
+        public static void InsertAt(this Group group, int index, IEnumerable<Entity> entities)
+        {
+            group.InsertAt(index, entities.Select(e => e.ObjectId));
+        }
+
+        /// <summary>
+        /// Removes ids from group at the index required. (Note, this crystalises the ids to an array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="ids"></param>
+        public static void Remove(this Group group, IEnumerable<ObjectId> ids)
+        {
+            ObjectId[] idsArray = ids.ToArray();
+
+            if (idsArray.Length > 0)
+            {
+                using (ObjectIdCollection idCollection = new ObjectIdCollection(idsArray))
+                {                    
+                    group.Remove(idCollection); 
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes entities from group at the index required. (Note, this crystalises the entity to an ids array, internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="entities"></param>
+        public static void Remove(this Group group, IEnumerable<Entity> entities)
+        {
+            group.Remove(entities.Select(e => e.ObjectId));
+        }
+
+        /// <summary>
+        /// Removes ids from the group (i.e. the objects whose object IDs are in the ids enumerable). All objects must be in the group and be at index locations equal to or higher than index. (Note, this crystalises the ids to an array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="index"></param>
+        /// <param name="ids"></param>
+        public static void RemoveAt(this Group group, int index, IEnumerable<ObjectId> ids)
+        {
+            ObjectId[] idsArray = ids.ToArray();
+
+            if (idsArray.Length > 0)
+            {
+                using (ObjectIdCollection idCollection = new ObjectIdCollection(idsArray))
+                {                    
+                    group.RemoveAt(index, idCollection); 
+                }
+            }
+        }
+
+        /// <summary>
+        /// Removes entities from the group. All objects must be in the group and be at index locations equal to or higher than index. (Note, this crystalises the entities into an ids array internally).
+        /// </summary>
+        /// <param name="group"></param>
+        /// <param name="index"></param>
+        /// <param name="entities"></param>
+        public static void RemoveAt(this Group group, int index, IEnumerable<Entity> entities)
+        {
+            group.RemoveAt(index, entities.Select(e => e.ObjectId));
+        }
+    }
+}


### PR DESCRIPTION
### What is this?

Adds extension methods to the `Group` class - convenience methods.

### Why?

Simplifies the client code a tiny bit.  People are used to working with entities, or object ids. Mainly, they should not be too concerned about `ObjectIdCollections` nor using Linq to convert from one Enumerable type to another.

```c#
/// Before
IEnumerable<Entity> entities = polylines.Cast<Entity>();
IEnumerable<ObjectId> ids = entities.Select(e => e.ObjectId);
ObjectIdCollection idCollection = new ObjectIdCollection(ids.ToArray());
Group group = getGroup();
group.Append(idCollection);


// After:
IEnumerable<Entity> entities = polylines.Cast<Entity>();
group.append(entities);
group.append(ids);
```

### Problems with the PR:

* I was not able to properly integrate it in the project.
* I have not utilised it in my actual project. I have however looked over it carefully enough.
* Also no documentation has been added just yet.


