### PR TITLE
add: docs - provide instructions on how to contribute

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -1,0 +1,20 @@
+### Contributing
+
+Please:
+
+- open an [issue](https://github.com/wtertinek/Linq2Acad/issues) if you've found a bug,
+- a [discussion](https://github.com/wtertinek/Linq2Acad/discussions/new) for a feature request, and then, 
+- a pull request if you want to help extending the library.
+
+
+There are 9 separate VS Projects associated with this repository - one for every version of AutoCAD from 2015 to 2023. But the associated source files are all the same. Consequently, all source files must be contained in the `.\Linq2Acad\src\Sources` directory, and must subsequently be linked to each project.
+
+The best way to do this is to Open the (.csproj) in a text editor and to add the following lines (amend the file names and paths):
+
+```xml
+<Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+  <Link>Extensions\GroupExtensions.cs</Link>
+</Compile>
+```
+
+For those with graphic design abilities: it would be nice to have a Linq2Acad logo.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Code samples in C# and VB.NET can be found [here](docs/CodeSamples.md).
 Please refer to [this blog series](https://wtertinek.com/2016/07/06/linq-and-the-autocad-net-api-final-part) which details in a step-by-step fashion: (i) how this library works and (ii) the decision making process and logic behind the library's derivation.
 
 ## Contributing
-
 See [contributing documentation](/Contributing.md).
 
 ## License

--- a/README.md
+++ b/README.md
@@ -82,9 +82,12 @@ Code samples in C# and VB.NET can be found [here](docs/CodeSamples.md).
 Please refer to [this blog series](https://wtertinek.com/2016/07/06/linq-and-the-autocad-net-api-final-part) which details in a step-by-step fashion: (i) how this library works and (ii) the decision making process and logic behind the library's derivation.
 
 ## Contributing
-Please contribute to this project by
-- opening an [issue](https://github.com/wtertinek/Linq2Acad/issues) if you found a bug or have a feature request
-- creating a pull request if you want to help extending the library
+
+Please:
+
+- open an [issue](https://github.com/wtertinek/Linq2Acad/issues) if you've found a bug,
+- a [discussion](https://github.com/wtertinek/Linq2Acad/discussions/new) for a feature request, and then, 
+- a pull request if you want to help extending the library.
 
 For those with graphic design abilities: it would be nice to have a Linq2Acad logo.
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ Please:
 - a [discussion](https://github.com/wtertinek/Linq2Acad/discussions/new) for a feature request, and then, 
 - a pull request if you want to help extending the library.
 
+
+There are 9 separate VS Projects associated with this repository - one for every version of AutoCAD from 2015 to 2023. But the associated source files are all the same. Consequently, all source files must be contained in the `.\Linq2Acad\src\Sources` directory, and must subsequently be linked to each project.
+
+The best way to do this is to Open the (.csproj) in a text editor and to add the following lines (amend the file names and paths):
+
+```xml
+<Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
+  <Link>Extensions\GroupExtensions.cs</Link>
+</Compile>
+```
+
 For those with graphic design abilities: it would be nice to have a Linq2Acad logo.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -83,24 +83,7 @@ Please refer to [this blog series](https://wtertinek.com/2016/07/06/linq-and-the
 
 ## Contributing
 
-Please:
-
-- open an [issue](https://github.com/wtertinek/Linq2Acad/issues) if you've found a bug,
-- a [discussion](https://github.com/wtertinek/Linq2Acad/discussions/new) for a feature request, and then, 
-- a pull request if you want to help extending the library.
-
-
-There are 9 separate VS Projects associated with this repository - one for every version of AutoCAD from 2015 to 2023. But the associated source files are all the same. Consequently, all source files must be contained in the `.\Linq2Acad\src\Sources` directory, and must subsequently be linked to each project.
-
-The best way to do this is to Open the (.csproj) in a text editor and to add the following lines (amend the file names and paths):
-
-```xml
-<Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
-  <Link>Extensions\GroupExtensions.cs</Link>
-</Compile>
-```
-
-For those with graphic design abilities: it would be nice to have a Linq2Acad logo.
+See [contributing documentation](/Contributing.md).
 
 ## License
 Linq2Acad is licended unter the [MIT License (MIT)](LICENSE).


### PR DESCRIPTION
### What is this?
Provides instructions on how to contribute, especially if adding files are required.

### Why?
Because this repository is a little tricky - there are 9 separate projects and new comers may get confused. (Also it is a reference for myself ;D).
