### PR TITLE
WIP: add line extension methods

### DIFF
--- a/src/AutoCAD_2022/Linq2Acad/Linq2Acad.csproj
+++ b/src/AutoCAD_2022/Linq2Acad/Linq2Acad.csproj
@@ -190,6 +190,9 @@
     <Compile Include="..\..\Sources\Linq2Acad\Extensions\GroupExtensions.cs">
       <Link>Extensions\GroupExtensions.cs</Link>
     </Compile>
+    <Compile Include="..\..\Sources\Linq2Acad\Extensions\LineExtensions.cs">
+      <Link>Extensions\LineExtensions.cs</Link>
+    </Compile>
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Sources/Linq2Acad.SampleCode.CS/SampleCode.cs
+++ b/src/Sources/Linq2Acad.SampleCode.CS/SampleCode.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Autodesk.AutoCAD.Colors;
 using Autodesk.AutoCAD.DatabaseServices;
+using Autodesk.AutoCAD.EditorInput;
 using Autodesk.AutoCAD.Geometry;
 using Autodesk.AutoCAD.Runtime;
 
@@ -369,6 +370,20 @@ namespace Linq2Acad
 
             WriteMessage("XRefs reloaded");
         }
+
+
+        [CommandMethod("Linq2AcadExample17")]
+        public void TestLineExtensions()
+        {
+            Line line = new Line()
+                            .From(z: 3)
+                            .To(x: 3);
+
+            WriteMessage(line.StartPoint.ToString()); // => (0,0,3)            
+            WriteMessage(line.EndPoint.ToString());   // => (3, 0, 0)
+            line.Dispose();
+        }
+
 
         [CommandMethod("AddEntitiesToGroup")]
         public void AddEntitiesToGroup()

--- a/src/Sources/Linq2Acad/Extensions/LineExtensions.cs
+++ b/src/Sources/Linq2Acad/Extensions/LineExtensions.cs
@@ -1,0 +1,60 @@
+using Autodesk.AutoCAD.DatabaseServices;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Autodesk.AutoCAD.Geometry;
+
+namespace Linq2Acad
+{
+  /// <summary>
+  /// Extension methods for instances of Line.
+  /// </summary>
+  public static class LineExtensions
+  {
+        /// <summary>
+        /// Modifies the start point of the line.
+        /// </summary>
+        /// <param name="line"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        /// <returns> Line </returns>
+        /// <code>
+        ///     line.From(2);           // line.StartPoint = new Point3d(2, 0, 0);
+        ///     line.From(x: 2);        // line.StartPoint = new Point3d(2, 0, 0);
+        ///     line.From(x: 2, y: 3);  // line.StartPoint = new Point3d(2, 3, 0);
+        ///     line.From(y: 3);        // line.StartPoint = new Point3d(0, 3, 0);
+        ///     line.From(2, 3);        // line.StartPoint = new Point3d(2, 3, 0);
+        ///     line.From(2, 3, z: 4);  // line.StartPoint = new Point3d(2, 3, 4);
+        /// </code>
+        public static Line From(this Line line, double x = 0, double y = 0, double z = 0) { 
+            line.StartPoint = new Point3d(x, y, z);
+            return line;
+        }
+
+        /// <summary>
+        /// Modifies the end point of the line.
+        /// </summary>
+        /// <param name="line"></param>
+        /// <param name="x"></param>
+        /// <param name="y"></param>
+        /// <param name="z"></param>
+        /// <returns> Line </returns>
+        /// <code>
+        ///     line.To(2);           // line.EndPoint = new Point3d(2, 0, 0);
+        ///     line.To(x: 2);        // line.EndPoint = new Point3d(2, 0, 0);
+        ///     line.To(x: 2, y: 3);  // line.EndPoint = new Point3d(2, 3, 0);
+        ///     line.To(y: 3);        // line.EndPoint = new Point3d(0, 3, 0);
+        ///     line.To(2, 3);        // line.EndPoint = new Point3d(2, 3, 0);
+        ///     line.To(2, 3, z: 4);  // line.EndPoint = new Point3d(2, 3, 4);
+        /// </code>
+        public static Line To(this Line line, double x = 0, double y = 0, double z = 0)
+        {
+            line.EndPoint = new Point3d(x, y, z);
+            return line;           
+        }
+    }
+}
+


### PR DESCRIPTION
WIP commit.

I implemented this as an extension method, rather than as a LineBuilder object.

```c#
Line line = new Line().From(z: 3).To(x: 3);

WriteMessage(line.StartPoint.ToString()); // => (0,0,3)            
WriteMessage(line.EndPoint.ToString());   // => (3, 0, 0)

line.Dispose();
```

Thoughts? 

- Would you use this extension method?
- Perhaps From should pass in a Point3d as well as doubles?

I have not added it to all the projects, just AutoCAD 22.

