### PR TITLE
Commit message check workflows

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -190,7 +190,7 @@ Each commit message consists of a **header**, a **body**, and a **footer** (the 
 
 The `header` is mandatory and must conform to the [Commit Message Header](#commit-header) format.
 
-The `body` is mandatory for all commits except for those of type "docs".
+The `body` is mandatory for all commits except for ["fixup!"](#addressing-review-feedback) and ["revert:"](#revert-commits) commits.
 When the body is present it must be at least 20 characters long and must conform to the [Commit Message Body](#commit-body) format.
 
 The `footer` is optional. The [Commit Message Footer](#commit-footer) format describes what the footer is used for and the structure it must have.
@@ -201,12 +201,12 @@ The `footer` is optional. The [Commit Message Footer](#commit-footer) format des
 ```
 <type>: <short summary>
   │            │
-  │            └─⫸ Summary in present tense. Not capitalized. No period at the end.
+  │            └─⫸ Summary in present tense
   │   
   └─⫸ Commit Type: chore|ci|docs|feat|fix|refactor|test
 ```
 
-The `<type>` and `<summary>` fields are mandatory
+Both fields (`<type>` and `<summary>`) are mandatory
 
 
 ##### Type
@@ -227,8 +227,6 @@ Must be one of the following:
 Use the summary field to provide a succinct description of the change:
 
 * use the imperative, present tense: "change" not "changed" nor "changes"
-* don't capitalize the first letter
-* no dot (.) at the end
 
 
 #### <a name="commit-body"></a>Commit Message Body

--- a/.github/workflows/feature-branch-commit-message-check.yml
+++ b/.github/workflows/feature-branch-commit-message-check.yml
@@ -1,0 +1,21 @@
+name: 'Feature Branch Commit Message Check'
+on:
+  push:
+    branches:
+      - !master
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Type
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^(chore|ci|docs|feat|fix|refactor|test)!?:\s.+$\n\n^.{20,}$|^(fixup!\s|revert:\s)(chore|ci|docs|feat|fix|refactor|test)!?:\s.+$(\n\n^.{20,})?$'
+          flags: 'gm'
+          error: 'At least one commmit message does not conform to the commmit message guidelines. See .github/CONTRIBUTING.md for details.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/master-commit-message-check.yml
+++ b/.github/workflows/master-commit-message-check.yml
@@ -1,0 +1,21 @@
+name: 'Master Commit Message Check'
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  check-commit-message:
+    name: Check Commit Message
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check Commit Type
+        uses: gsactions/commit-message-checker@v2
+        with:
+          pattern: '^(chore|ci|docs|feat|fix|refactor|test)!?:\s.+$\n\n^.{20,}$|^revert:\s(chore|ci|docs|feat|fix|refactor|test)!?:\s.+$(\n\n^.{20,})?$'
+          flags: 'gm'
+          error: 'At least one commmit message does not conform to the commmit message guidelines. See .github/CONTRIBUTING.md for details.'
+          excludeDescription: 'true'
+          excludeTitle: 'true'
+          checkAllCommitMessages: 'true'
+          accessToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

Add two workflows that check if commit messages conform to the guidelines. One workflow for feature branches, one for the master branch. The only difference is that on master the `fixup!` prefix is not allowed.

A check is executed every time code is pushed to the repo. Not sure yet if on-push is the best way to do it. It generates fast feedback, which is good. But the check could just as well be executed only when a pull request is created or modified. I think we can tweak that later.

The consequence of a failed commit message check is that a subsequent pull request will not be merable.

## Type of change

- [x] Process and quality improvement

## Checklist:

- [ ] My code follows the style guidelines of this project
- [x] Commit messages follow the [guidlines](.github/CONTRIBUTING.md#commit)
- [ ] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked my code and corrected any misspellings