### PR TITLE
fix: drawing not saved when using OpenForEdit

### DIFF
--- a/src/Linq2Acad/AcadDatabase.cs
+++ b/src/Linq2Acad/AcadDatabase.cs
@@ -27,7 +27,7 @@ namespace Linq2Acad
     private AcadDatabase(Database database, bool keepOpen, string outFileName, SaveAsDwgVersion dwgVersion)
       : this(database, database.TransactionManager.StartTransaction(), true, true)
     {
-      saveOnCommit = saveAsFileName != null;
+      saveOnCommit = outFileName != null;
       saveAsFileName = outFileName;
       this.dwgVersion = dwgVersion;
       disposeDatabase = !keepOpen;


### PR DESCRIPTION
# Pull Request Template

## Description

I know you said you'll fix it, but why wait for a simple fix like this 😉 

Fixes #49

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I used my code to debug and check that the `saveOnCommit` field is set to true and that my drawings are correctly saved.

a quick test could be

```cs
var path = @"C:\drawing.dwg";
var createOptions = new CreateOptions(){SaveFileName = path};
using (var dbCreate = AcadDatabase.Create(createOptions) {
  // create some element
}
using (var dbEdit = AcadDatabase.OpenForedit(path) {
  // edit the element
}
using (var dbRead = AcadDatabase.OpenReadOnly(path) {
  // check that the element is changed
}
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] Commit messages follow the [guidlines](.github/CONTRIBUTING.md#commit)
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings